### PR TITLE
_which() fix: Added a copy of the path string because strtok was dest…

### DIFF
--- a/_which.c
+++ b/_which.c
@@ -4,7 +4,7 @@
 char *_which(char *filename)
 {
 	struct stat sb;
-	char *path_var, *delimiter, *file_path;
+	char *path_var, *path_var_cpy,*delimiter, *file_path;
 	char **array_of_tokens;
 	int token_index, file_path_exist;
 
@@ -15,7 +15,14 @@ char *_which(char *filename)
 		perror("_which Error: getenv returned NULL");
 		return (NULL);
 	}
-	array_of_tokens = array_maker(path_var, delimiter);
+	path_var_cpy = (char *) malloc(sizeof(char) * strlen(path_var));
+	if (path_var_cpy == NULL)
+	{
+		perror("_which Error: malloc error path_var_cpy is NULL");
+		return (NULL);
+	}
+	strcpy(path_var_cpy, path_var);
+	array_of_tokens = array_maker(path_var_cpy, delimiter);
 	if (!array_of_tokens)
 	{
 		perror("_which Error: array_of_tokens is NULL");
@@ -33,18 +40,14 @@ char *_which(char *filename)
 		strcat(file_path, "/");
 		strcat(file_path, filename);
 		strcat(file_path, "\0");
-
 		file_path_exist = stat(file_path, &sb);
 		if (file_path_exist == -1)
-		{
 			free(file_path);
-		}
 		else if (file_path_exist == 0)
 			return (file_path);
 	}
 	file_path_exist = stat(filename, &sb);
 	if (file_path_exist == 0)
 		return (filename);
-
 	return (NULL);
 }


### PR DESCRIPTION
# _which() FIX

```
char *path_var_cpy;

path_var_cpy = (char *) malloc(sizeof(char) * strlen(path_var));
if (path_var_cpy == NULL)
{
  perror("_which Error: malloc error path_var_cpy is NULL");
  return (NULL);
}
  strcpy(path_var_cpy, path_var);
  array_of_tokens = array_maker(path_var_cpy, delimiter);
```

Added the above to fix the code 

It was happening because the char *path_var  variable was being messed up by the **strtok** function in the **_array_maker** so I gave it a **copy** instead and all seems well